### PR TITLE
Relative key paths fix

### DIFF
--- a/Sources/VaporAPNS/String+APNS.swift
+++ b/Sources/VaporAPNS/String+APNS.swift
@@ -24,12 +24,8 @@ extension String {
     
     /// Converts the string (which is a path for the auth key) to a token string
     func tokenString() throws -> (privateKey: String, publicKey: String) {
-        guard let authKeyUrl = URL(string: "file://\(self)") else {
-            throw TokenError.invalidAuthKey
-        }
-
         // Fold p8 file and write it back to the file
-        let fileString = try String(contentsOf: authKeyUrl, encoding: .utf8)
+        let fileString = try String(contentsOfFile: self, encoding: .utf8)
         guard
             let privateKeyString =
             fileString.collapseWhitespace().trimmingCharacters(in: .whitespaces).between(


### PR DESCRIPTION
When i deploy to Heroku, VaporAPNS crashes for me becouse key file path is "./Resources/asdfs.p8"