### PR TITLE
Support subtitle for iOS 10

### DIFF
--- a/Sources/VaporAPNS/Payload.swift
+++ b/Sources/VaporAPNS/Payload.swift
@@ -17,6 +17,9 @@ open class Payload: JSONRepresentable {
     /// A short string describing the purpose of the notification. Apple Watch displays this string as part of the notification interface. This string is displayed only briefly and should be crafted so that it can be understood quickly. This key was added in iOS 8.2.
     public var title: String?
     
+    // A secondary description of the reason for the alert.
+    public var subtitle: String?
+
     /// The text of the alert message. Can be nil if using titleLocKey
     public var body: String?
     
@@ -82,6 +85,10 @@ open class Payload: JSONRepresentable {
             }
         }
         
+        if let subtitle = subtitle {
+            alert["subtitle"] = subtitle
+        }
+
         if let body = body {
             alert["body"] = body
         }else {

--- a/Tests/VaporAPNSTests/PayloadTests.swift
+++ b/Tests/VaporAPNSTests/PayloadTests.swift
@@ -48,7 +48,18 @@ class PayloadTests: XCTestCase { // TODO: Set this up so others can test this ðŸ
         
         XCTAssertEqual(plString, expectedJSON)
     }
-    
+
+    func testTitleSubtitleBodyPush() throws {
+        let expectedJSON = "{\"aps\":{\"alert\":{\"body\":\"Test body\",\"subtitle\":\"Test subtitle\",\"title\":\"Test title\"}}}"
+
+        let payload = Payload.init(title: "Test title", body: "Test body")
+        payload.subtitle = "Test subtitle"
+        let plJosn = try payload.makeJSON()
+        let plString = try plJosn.toString()
+
+        XCTAssertEqual(plString, expectedJSON)
+    }
+
     func testContentAvailablePush() throws {
         let expectedJSON = "{\"aps\":{\"content-available\":true}}"
         


### PR DESCRIPTION
Support aps.alert.subtitle for iOS 10.

https://developer.apple.com/reference/usernotifications/unnotificationcontent/1649859-subtitle

![screen shot 2017-01-13 at 12 44 08](https://cloud.githubusercontent.com/assets/629993/21917808/007246b0-d98e-11e6-8140-d0da000047cb.png)
