### PR TITLE
Fix "thread-id" payload

### DIFF
--- a/Sources/VaporAPNS/ApplePushMessage.swift
+++ b/Sources/VaporAPNS/ApplePushMessage.swift
@@ -18,8 +18,6 @@ public struct ApplePushMessage {
     
     public let collapseIdentifier: String?
 
-    public let threadIdentifier: String?
-
     public let expirationDate: Date?
     
     /// APNS Priority
@@ -40,14 +38,13 @@ public struct ApplePushMessage {
     /// Use sandbox server URL or not
     public let sandbox:Bool
     
-    public init(topic: String? = nil, priority: Priority, expirationDate: Date? = nil, payload: Payload, sandbox:Bool = true, collapseIdentifier: String? = nil, threadIdentifier: String? = nil) {
+    public init(topic: String? = nil, priority: Priority, expirationDate: Date? = nil, payload: Payload, sandbox:Bool = true, collapseIdentifier: String? = nil) {
         self.topic = topic
         self.priority = priority
         self.expirationDate = expirationDate
         self.payload = payload
         self.sandbox = sandbox
         self.collapseIdentifier = collapseIdentifier
-        self.threadIdentifier = threadIdentifier
     }
     
 }

--- a/Sources/VaporAPNS/Payload.swift
+++ b/Sources/VaporAPNS/Payload.swift
@@ -127,6 +127,10 @@ open class Payload: JSONRepresentable {
             if hasMutableContent {
                 apsPayloadData["mutable-content"] = 1
             }
+
+            if let threadId = threadId {
+                apsPayloadData["thread-id"] = threadId
+            }
             
         }
         

--- a/Sources/VaporAPNS/VaporAPNS.swift
+++ b/Sources/VaporAPNS/VaporAPNS.swift
@@ -193,10 +193,6 @@ open class VaporAPNS {
             headers["apns-collapse-id"] = collapseId
         }
         
-        if let threadId = message.threadIdentifier {
-            headers["thread-id"] = threadId
-        }
-        
         return headers
         
     }

--- a/Tests/VaporAPNSTests/ApplePushMessageTests.swift
+++ b/Tests/VaporAPNSTests/ApplePushMessageTests.swift
@@ -14,12 +14,11 @@ class ApplePushMessageTests: XCTestCase {
     
     func testInitializer() {
         let simplePayload = Payload(message: "Test message")
-        let pushMessage = ApplePushMessage(topic: "com.apple.Test", priority: .immediately, expirationDate: nil, payload: simplePayload,sandbox: true, collapseIdentifier: "collapseID", threadIdentifier: "threadId")
+        let pushMessage = ApplePushMessage(topic: "com.apple.Test", priority: .immediately, expirationDate: nil, payload: simplePayload,sandbox: true, collapseIdentifier: "collapseID")
         
         XCTAssertEqual(pushMessage.topic, "com.apple.Test")
         XCTAssertTrue(pushMessage.sandbox)
         XCTAssertEqual(pushMessage.collapseIdentifier, "collapseID")
-        XCTAssertEqual(pushMessage.threadIdentifier, "threadId")
         XCTAssertEqual(pushMessage.priority, .immediately)
         XCTAssertNil(pushMessage.expirationDate)
         XCTAssertEqual(try! pushMessage.payload.makeJSON(), try! simplePayload.makeJSON())

--- a/Tests/VaporAPNSTests/PayloadTests.swift
+++ b/Tests/VaporAPNSTests/PayloadTests.swift
@@ -71,6 +71,20 @@ class PayloadTests: XCTestCase {
         XCTAssertEqual(plNode["aps"]?["alert"]?["subtitle"]?.string, expectedJSON["aps"]?["alert"]?["subtitle"]?.string)
     }
 
+    func testSimpleWithThreadIdPush() throws {
+        let expectedJSON = Node(node: .object(["aps": .object(["alert": .object(["body": .string("Test")]), "thread-id": .string("Test Thread Id")])]), in: nil)
+
+        let payload = Payload(message: "Test")
+        payload.threadId = "Test Thread Id"
+        let plJSON = try payload.makeJSON()
+        let plNode = plJSON.makeNode(in: nil)
+
+        XCTAssertNotNil(plNode["aps"]?["alert"]?["body"]?.string)
+        XCTAssertEqual(plNode["aps"]?["alert"]?["body"]?.string, expectedJSON["aps"]?["alert"]?["body"]?.string)
+        XCTAssertNotNil(plNode["aps"]?["thread-id"]?.string)
+        XCTAssertEqual(plNode["aps"]?["thread-id"]?.string, expectedJSON["aps"]?["thread-id"]?.string)
+    }
+
     func testContentAvailablePush() throws {
         let expectedJSON = Node(node: .object(["aps": .object(["content-available": .bool(true)])]), in: nil)
         
@@ -104,6 +118,7 @@ class PayloadTests: XCTestCase {
             ("testSimplePush", testSimplePush),
             ("testTitleBodyPush", testTitleBodyPush),
             ("testTitleBodyBadgePush", testTitleBodyBadgePush),
+            ("testSimpleWithThreadIdPush", testSimpleWithThreadIdPush),
             ("testContentAvailablePush", testContentAvailablePush),
             ("testContentAvailableWithExtrasPush", testContentAvailableWithExtrasPush),
         ]


### PR DESCRIPTION
Originally, Payload had `threadId` property, but it doesn't use it. I think this is a mistake.
And, ApplePushMessage had `threadId` and uses it, but it doesn't make sense.

`aps` payload should contain `thread-id` if needed.

- [Local and Remote Notification Programming Guide: Payload Key Reference](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1)
- [threadIdentifier - UNNotificationContent | Apple Developer Documentation](https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649860-threadidentifier)

> For remote notifications, the value of this property is set to the value of the thread-id key in the aps dictionary.